### PR TITLE
Dev (introduces support for a new high-performance Zig-based packet adapter in addition to the existing C adapter)

### DIFF
--- a/scripts/benchmark_adapters.sh
+++ b/scripts/benchmark_adapters.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# Benchmark script to compare C vs Zig packet adapters
+# Usage: ./benchmark_adapters.sh <server> <port> <hub> <user> <password>
+
+set -e
+
+SERVER="${1:-vpn.worxsolutions.net}"
+PORT="${2:-443}"
+HUB="${3:-SSTP}"
+USER="${4:-itsalfredakku}"
+PASSWORD="${5}"
+
+if [ -z "$PASSWORD" ]; then
+    echo "Error: Password required"
+    echo "Usage: $0 <server> <port> <hub> <user> <password>"
+    exit 1
+fi
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+RESULTS_DIR="benchmark_results/adapter_comparison_${TIMESTAMP}"
+mkdir -p "$RESULTS_DIR"
+
+echo "=========================================="
+echo "SoftEther VPN Adapter Benchmark"
+echo "=========================================="
+echo "Server:    $SERVER:$PORT"
+echo "Hub:       $HUB"
+echo "User:      $USER"
+echo "Results:   $RESULTS_DIR"
+echo ""
+
+# Test 1: C Adapter (baseline)
+echo "=========================================="
+echo "Test 1: C Packet Adapter (baseline)"
+echo "=========================================="
+echo "Building with C adapter..."
+zig build 2>&1 | grep -E "(Building|error)" || true
+
+echo ""
+echo "Running VPN client with C adapter for 60 seconds..."
+timeout 60s zig-out/bin/vpnclient \
+    -s "$SERVER" \
+    -p "$PORT" \
+    -H "$HUB" \
+    -u "$USER" \
+    -P "$PASSWORD" \
+    --profile \
+    2>&1 | tee "$RESULTS_DIR/c_adapter.log" || true
+
+echo ""
+echo "C adapter test complete. Results saved to $RESULTS_DIR/c_adapter.log"
+sleep 5
+
+# Test 2: Zig Adapter
+echo ""
+echo "=========================================="
+echo "Test 2: Zig Packet Adapter"
+echo "=========================================="
+echo "Building with Zig adapter..."
+zig build -Duse-zig-adapter=true 2>&1 | grep -E "(Building|error|Zig)" || true
+
+echo ""
+echo "Running VPN client with Zig adapter for 60 seconds..."
+timeout 60s zig-out/bin/vpnclient \
+    -s "$SERVER" \
+    -p "$PORT" \
+    -H "$HUB" \
+    -u "$USER" \
+    -P "$PASSWORD" \
+    --profile \
+    2>&1 | tee "$RESULTS_DIR/zig_adapter.log" || true
+
+echo ""
+echo "Zig adapter test complete. Results saved to $RESULTS_DIR/zig_adapter.log"
+
+# Generate comparison report
+echo ""
+echo "=========================================="
+echo "Generating comparison report..."
+echo "=========================================="
+
+cat > "$RESULTS_DIR/COMPARISON.md" << EOF
+# Packet Adapter Comparison Report
+
+**Test Date:** $(date)
+**Server:** $SERVER:$PORT
+**Hub:** $HUB
+**Duration:** 60 seconds each
+
+## Test Configuration
+- **C Adapter:** Traditional single-packet polling
+- **Zig Adapter:** Batch processing with lock-free ring buffers
+  - RX Queue: 8192 packets
+  - TX Queue: 4096 packets
+  - Batch Size: 32 packets
+  - Memory Pool: Pre-allocated packet buffers
+
+## Results
+
+### C Adapter (Baseline)
+\`\`\`
+$(grep -E "Performance|Throughput|pps|Mbps" "$RESULTS_DIR/c_adapter.log" | tail -10)
+\`\`\`
+
+### Zig Adapter
+\`\`\`
+$(grep -E "Performance|Throughput|pps|Mbps" "$RESULTS_DIR/zig_adapter.log" | tail -10)
+\`\`\`
+
+## Analysis
+
+### Throughput Comparison
+EOF
+
+# Extract final throughput numbers
+C_MBPS=$(grep "Throughput:" "$RESULTS_DIR/c_adapter.log" | tail -1 | grep -o "[0-9.]*" | head -1 || echo "N/A")
+ZIG_MBPS=$(grep "Throughput:" "$RESULTS_DIR/zig_adapter.log" | tail -1 | grep -o "[0-9.]*" | head -1 || echo "N/A")
+
+C_PPS=$(grep "pps" "$RESULTS_DIR/c_adapter.log" | tail -1 | grep -o "[0-9.]*" | head -1 || echo "N/A")
+ZIG_PPS=$(grep "pps" "$RESULTS_DIR/zig_adapter.log" | tail -1 | grep -o "[0-9.]*" | head -1 || echo "N/A")
+
+echo "- **C Adapter:** ${C_MBPS} Mbps @ ${C_PPS} pps" >> "$RESULTS_DIR/COMPARISON.md"
+echo "- **Zig Adapter:** ${ZIG_MBPS} Mbps @ ${ZIG_PPS} pps" >> "$RESULTS_DIR/COMPARISON.md"
+
+# Calculate improvement if numbers are valid
+if [ "$C_MBPS" != "N/A" ] && [ "$ZIG_MBPS" != "N/A" ]; then
+    IMPROVEMENT=$(echo "scale=2; ($ZIG_MBPS - $C_MBPS) / $C_MBPS * 100" | bc 2>/dev/null || echo "N/A")
+    if [ "$IMPROVEMENT" != "N/A" ]; then
+        echo "- **Improvement:** ${IMPROVEMENT}%" >> "$RESULTS_DIR/COMPARISON.md"
+    fi
+fi
+
+cat >> "$RESULTS_DIR/COMPARISON.md" << EOF
+
+### Observations
+- Lock-free queues reduce contention between packet I/O and VPN processing
+- Batch processing amortizes syscall overhead
+- Memory pooling reduces allocation/deallocation overhead
+- SPSC (single-producer-single-consumer) design matches VPN session model
+
+## Next Steps
+1. If improvement < 2x, investigate packet loss and queue saturation
+2. Profile CPU usage to identify remaining bottlenecks
+3. Consider tuning queue sizes and batch parameters
+4. Test with different packet sizes and traffic patterns
+EOF
+
+echo ""
+echo "=========================================="
+echo "Benchmark Complete!"
+echo "=========================================="
+echo "Results saved to: $RESULTS_DIR/"
+echo ""
+cat "$RESULTS_DIR/COMPARISON.md"
+
+# Rebuild with default (C adapter) for normal usage
+echo ""
+echo "Rebuilding with default C adapter..."
+zig build 2>&1 | grep -E "(Building|error)" || true

--- a/src/bridge/softether_bridge.c
+++ b/src/bridge/softether_bridge.c
@@ -24,7 +24,20 @@
 // Platform-specific packet adapter
 #if defined(UNIX_MACOS)
     #include "packet_adapter_macos.h"
-    #define NEW_PACKET_ADAPTER() NewMacOsTunAdapter()
+    #include "zig_packet_adapter.h"
+    
+    // Toggle between C and Zig adapter (set to 1 to use Zig adapter)
+    #ifndef USE_ZIG_ADAPTER
+    #define USE_ZIG_ADAPTER 0  // Default: use C adapter (change to 1 for Zig)
+    #endif
+    
+    #if USE_ZIG_ADAPTER
+        #define NEW_PACKET_ADAPTER() NewZigPacketAdapter()
+        #pragma message("Building with Zig packet adapter")
+    #else
+        #define NEW_PACKET_ADAPTER() NewMacOsTunAdapter()
+        #pragma message("Building with C packet adapter")
+    #endif
 #elif defined(UNIX_LINUX)
     #include "packet_adapter_linux.h"
     #define NEW_PACKET_ADAPTER() NewLinuxTunAdapter()

--- a/src/bridge/zig_packet_adapter.c
+++ b/src/bridge/zig_packet_adapter.c
@@ -1,0 +1,216 @@
+// Zig Packet Adapter - C Wrapper Implementation
+// Wraps Zig packet adapter to provide SoftEther PACKET_ADAPTER interface
+
+#include "zig_packet_adapter.h"
+#include "logging.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Forward declarations of SoftEther callbacks
+static bool ZigAdapterInit(SESSION* s);
+static CANCEL* ZigAdapterGetCancel(SESSION* s);
+static UINT ZigAdapterGetNextPacket(SESSION* s, void** data);
+static bool ZigAdapterPutPacket(SESSION* s, void* data, UINT size);
+static void ZigAdapterFree(SESSION* s);
+
+// Create new Zig packet adapter
+PACKET_ADAPTER* NewZigPacketAdapter(void) {
+    printf("[NewZigPacketAdapter] Creating Zig packet adapter\n");
+    
+    // Allocate PACKET_ADAPTER structure
+    PACKET_ADAPTER* pa = ZeroMalloc(sizeof(PACKET_ADAPTER));
+    if (!pa) {
+        printf("[NewZigPacketAdapter] Failed to allocate PACKET_ADAPTER\n");
+        return NULL;
+    }
+    
+    // Set up callbacks
+    pa->Init = ZigAdapterInit;
+    pa->GetCancel = ZigAdapterGetCancel;
+    pa->GetNextPacket = ZigAdapterGetNextPacket;
+    pa->PutPacket = ZigAdapterPutPacket;
+    pa->Free = ZigAdapterFree;
+    
+    // Generate unique ID
+    static UINT next_id = 1;
+    pa->Id = next_id++;
+    
+    printf("[NewZigPacketAdapter] Created adapter with callbacks, Id=%u\n", pa->Id);
+    return pa;
+}
+
+// Initialize adapter
+static bool ZigAdapterInit(SESSION* s) {
+    printf("[ZigAdapterInit] Initializing Zig adapter for session %p\n", s);
+    
+    if (!s) {
+        printf("[ZigAdapterInit] ERROR: Session is NULL\n");
+        return false;
+    }
+    
+    // Allocate context
+    ZIG_ADAPTER_CONTEXT* ctx = ZeroMalloc(sizeof(ZIG_ADAPTER_CONTEXT));
+    if (!ctx) {
+        printf("[ZigAdapterInit] Failed to allocate context\n");
+        return false;
+    }
+    
+    ctx->session = s;
+    ctx->halt = false;
+    
+    // Create cancel handle
+    ctx->cancel = NewCancel();
+    if (!ctx->cancel) {
+        printf("[ZigAdapterInit] Failed to create cancel handle\n");
+        Free(ctx);
+        return false;
+    }
+    
+    // Configure Zig adapter
+    ZigAdapterConfig config = {
+        .recv_queue_size = 8192,
+        .send_queue_size = 4096,
+        .packet_pool_size = 16384,
+        .batch_size = 32,
+        .device_name = "utun",
+    };
+    
+    printf("[ZigAdapterInit] Creating Zig adapter with config: recv_q=%llu, send_q=%llu, pool=%llu, batch=%llu\n",
+           config.recv_queue_size, config.send_queue_size, config.packet_pool_size, config.batch_size);
+    
+    // Create Zig adapter
+    ctx->zig_adapter = zig_adapter_create(&config);
+    if (!ctx->zig_adapter) {
+        printf("[ZigAdapterInit] Failed to create Zig adapter\n");
+        ReleaseCancel(ctx->cancel);
+        Free(ctx);
+        return false;
+    }
+    
+    printf("[ZigAdapterInit] Zig adapter created at %p\n", ctx->zig_adapter);
+    
+    // Open TUN device
+    if (!zig_adapter_open(ctx->zig_adapter)) {
+        printf("[ZigAdapterInit] Failed to open TUN device\n");
+        zig_adapter_destroy(ctx->zig_adapter);
+        ReleaseCancel(ctx->cancel);
+        Free(ctx);
+        return false;
+    }
+    
+    printf("[ZigAdapterInit] TUN device opened successfully\n");
+    
+    // Start adapter threads
+    if (!zig_adapter_start(ctx->zig_adapter)) {
+        printf("[ZigAdapterInit] Failed to start adapter threads\n");
+        zig_adapter_destroy(ctx->zig_adapter);
+        ReleaseCancel(ctx->cancel);
+        Free(ctx);
+        return false;
+    }
+    
+    printf("[ZigAdapterInit] Zig adapter started successfully\n");
+    
+    // Store context in session
+    s->PacketAdapter->Param = ctx;
+    
+    printf("[ZigAdapterInit] ✅ Initialization complete\n");
+    return true;
+}
+
+// Get cancel handle
+static CANCEL* ZigAdapterGetCancel(SESSION* s) {
+    if (!s || !s->PacketAdapter || !s->PacketAdapter->Param) {
+        return NULL;
+    }
+    
+    ZIG_ADAPTER_CONTEXT* ctx = (ZIG_ADAPTER_CONTEXT*)s->PacketAdapter->Param;
+    return ctx->cancel;
+}
+
+// Get next packet (single packet mode - for compatibility)
+static UINT ZigAdapterGetNextPacket(SESSION* s, void** data) {
+    if (!s || !s->PacketAdapter || !s->PacketAdapter->Param) {
+        return 0;
+    }
+    
+    ZIG_ADAPTER_CONTEXT* ctx = (ZIG_ADAPTER_CONTEXT*)s->PacketAdapter->Param;
+    
+    if (ctx->halt) {
+        return 0;
+    }
+    
+    // Get packet from Zig adapter
+    uint8_t* packet_data = NULL;
+    uint64_t packet_len = 0;
+    
+    if (!zig_adapter_get_packet(ctx->zig_adapter, &packet_data, &packet_len)) {
+        // No packet available
+        return 0;
+    }
+    
+    if (packet_len == 0 || packet_len > 2048) {
+        return 0;
+    }
+    
+    // Allocate buffer for packet
+    void* packet_copy = Malloc((UINT)packet_len);
+    if (!packet_copy) {
+        return 0;
+    }
+    
+    // Copy packet data
+    Copy(packet_copy, packet_data, (UINT)packet_len);
+    *data = packet_copy;
+    
+    return (UINT)packet_len;
+}
+
+// Put packet for transmission
+static bool ZigAdapterPutPacket(SESSION* s, void* data, UINT size) {
+    if (!s || !s->PacketAdapter || !s->PacketAdapter->Param || !data || size == 0) {
+        return false;
+    }
+    
+    ZIG_ADAPTER_CONTEXT* ctx = (ZIG_ADAPTER_CONTEXT*)s->PacketAdapter->Param;
+    
+    if (ctx->halt) {
+        return false;
+    }
+    
+    // Send packet to Zig adapter
+    return zig_adapter_put_packet(ctx->zig_adapter, (const uint8_t*)data, (uint64_t)size);
+}
+
+// Free adapter
+static void ZigAdapterFree(SESSION* s) {
+    printf("[ZigAdapterFree] Freeing Zig adapter\n");
+    
+    if (!s || !s->PacketAdapter || !s->PacketAdapter->Param) {
+        return;
+    }
+    
+    ZIG_ADAPTER_CONTEXT* ctx = (ZIG_ADAPTER_CONTEXT*)s->PacketAdapter->Param;
+    ctx->halt = true;
+    
+    // Print final stats
+    printf("[ZigAdapterFree] Final statistics:\n");
+    zig_adapter_print_stats(ctx->zig_adapter);
+    
+    // Stop adapter
+    zig_adapter_stop(ctx->zig_adapter);
+    
+    // Destroy Zig adapter
+    zig_adapter_destroy(ctx->zig_adapter);
+    
+    // Release cancel
+    if (ctx->cancel) {
+        ReleaseCancel(ctx->cancel);
+    }
+    
+    // Free context
+    Free(ctx);
+    
+    printf("[ZigAdapterFree] ✅ Cleanup complete\n");
+}

--- a/src/bridge/zig_packet_adapter.h
+++ b/src/bridge/zig_packet_adapter.h
@@ -1,0 +1,63 @@
+// Zig Packet Adapter - C FFI Header
+// Provides C-compatible interface to Zig packet adapter
+
+#ifndef ZIG_PACKET_ADAPTER_H
+#define ZIG_PACKET_ADAPTER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Include SoftEther headers first (they define bool and other types)
+#include "../../SoftEtherVPN_Stable/src/Mayaqua/Mayaqua.h"
+#include "../../SoftEtherVPN_Stable/src/Cedar/Cedar.h"
+
+// Standard headers (after SoftEther to avoid bool conflicts)
+#include <stdint.h>
+
+// Opaque handle to Zig adapter
+typedef struct ZigPacketAdapter ZigPacketAdapter;
+
+// Configuration for Zig adapter
+typedef struct {
+    uint64_t recv_queue_size;
+    uint64_t send_queue_size;
+    uint64_t packet_pool_size;
+    uint64_t batch_size;
+    const char* device_name;
+} ZigAdapterConfig;
+
+// Packet buffer structure (matches Zig side)
+typedef struct {
+    uint8_t* data;
+    uint64_t len;
+    int64_t timestamp;
+} ZigPacketBuffer;
+
+// Zig adapter FFI functions (exported from adapter.zig)
+extern ZigPacketAdapter* zig_adapter_create(const ZigAdapterConfig* config);
+extern void zig_adapter_destroy(ZigPacketAdapter* adapter);
+extern bool zig_adapter_open(ZigPacketAdapter* adapter);
+extern bool zig_adapter_start(ZigPacketAdapter* adapter);
+extern void zig_adapter_stop(ZigPacketAdapter* adapter);
+extern bool zig_adapter_get_packet(ZigPacketAdapter* adapter, uint8_t** out_data, uint64_t* out_len);
+extern uint64_t zig_adapter_get_packet_batch(ZigPacketAdapter* adapter, ZigPacketBuffer* out_array, uint64_t max_count);
+extern bool zig_adapter_put_packet(ZigPacketAdapter* adapter, const uint8_t* data, uint64_t len);
+extern void zig_adapter_print_stats(ZigPacketAdapter* adapter);
+
+// Create SoftEther PACKET_ADAPTER that wraps Zig adapter
+PACKET_ADAPTER* NewZigPacketAdapter(void);
+
+// Context for Zig adapter wrapper
+typedef struct {
+    SESSION* session;
+    ZigPacketAdapter* zig_adapter;
+    CANCEL* cancel;
+    bool halt;
+} ZIG_ADAPTER_CONTEXT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ZIG_PACKET_ADAPTER_H

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -63,6 +63,7 @@ fn printUsage() void {
         \\    --no-compress           Disable compression
         \\    -d, --daemon            Run as daemon (background)
         \\    --profile               Enable performance profiling
+        \\    --use-zig-adapter       Use Zig packet adapter (experimental, better performance)
         \\    --log-level <LEVEL>     Set log verbosity: silent, error, warn, info, debug, trace (default: info)
         \\    --ip-version <VERSION>  IP version: auto, ipv4, ipv6, dual (default: auto)
         \\    --static-ipv4 <IP>      Static IPv4 address (e.g., 10.0.0.2)
@@ -120,6 +121,7 @@ const CliArgs = struct {
     max_connection: u32 = 0, // 0 = follow server policy, 1-32 = force specific count
     daemon: bool = false,
     profile: bool = false, // Enable performance profiling
+    use_zig_adapter: bool = false, // Use Zig packet adapter instead of C adapter
     log_level: []const u8 = "info",
     ip_version: []const u8 = "auto",
     static_ipv4: ?[]const u8 = null,
@@ -186,6 +188,8 @@ fn parseArgs(allocator: std.mem.Allocator) !CliArgs {
             result.daemon = true;
         } else if (std.mem.eql(u8, arg, "--profile")) {
             result.profile = true;
+        } else if (std.mem.eql(u8, arg, "--use-zig-adapter")) {
+            result.use_zig_adapter = true;
         } else if (std.mem.eql(u8, arg, "--log-level")) {
             result.log_level = args.next() orelse return error.MissingLogLevel;
         } else if (std.mem.eql(u8, arg, "--ip-version")) {

--- a/test_zig_adapter.sh
+++ b/test_zig_adapter.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Quick test script for Zig adapter with debug output
+# Usage: sudo ./test_zig_adapter.sh
+
+set -e
+
+echo "=========================================="
+echo "Zig Adapter Debug Test"
+echo "=========================================="
+echo ""
+
+echo "Building with Zig adapter..."
+zig build -Duse-zig-adapter=true
+
+echo ""
+echo "Running VPN client (will stop after 10 seconds)..."
+echo ""
+
+timeout 10s sudo ./zig-out/bin/vpnclient \
+  --server worxvpn.662.cloud \
+  --port 443 \
+  --hub VPN \
+  --user devstroop \
+  --password-hash "T2kl2mB84H5y2tn7n9qf65/8jXI=" \
+  --log-level error \
+  --ip-version ipv4 \
+  --profile \
+  2>&1 | tee zig_adapter_test.log || true
+
+echo ""
+echo "=========================================="
+echo "Test complete. Check zig_adapter_test.log for details."
+echo ""
+echo "Looking for Zig adapter initialization messages..."
+echo "=========================================="
+grep -E "\[zig_adapter|ZigPacketAdapter\]" zig_adapter_test.log || echo "No Zig adapter messages found!"


### PR DESCRIPTION
This pull request introduces support for a new high-performance Zig-based packet adapter in addition to the existing C adapter, and provides tooling to benchmark and debug the new adapter. It adds a build flag and CLI option to select the Zig adapter, implements a C wrapper and FFI interface for integration, and includes scripts for benchmarking and testing. The changes are organized into build system updates, adapter implementation, CLI integration, and developer tooling.

**Build system and configuration:**

* Added a `use-zig-adapter` build option to `build.zig`, allowing selection between the C and Zig packet adapters at build time. The build script now conditionally defines `USE_ZIG_ADAPTER` and includes the new Zig adapter source file. [[1]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR7-R9) [[2]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccL46-R74) [[3]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR96)
* Updated `src/bridge/softether_bridge.c` to conditionally use the Zig or C packet adapter based on the `USE_ZIG_ADAPTER` macro.

**Zig packet adapter implementation and integration:**

* Added `src/bridge/zig_packet_adapter.c` and `zig_packet_adapter.h`, providing a C wrapper and FFI interface to the Zig adapter, exposing creation, destruction, and packet I/O functions, and implementing the SoftEther `PACKET_ADAPTER` interface. [[1]](diffhunk://#diff-632a7bef2da113facb7b13b6ec81414cc391d77e3cf2e69d14873062c3e27510R1-R216) [[2]](diffhunk://#diff-11b31165be0fdd1a0e6ceeedd54c07babc6ca2f3bf409ce10e3a52fc7f4f1c87R1-R63)
* Improved debug output and error handling in the Zig adapter implementation (`src/packet/adapter.zig`), including initialization logs and error reporting for FFI creation. [[1]](diffhunk://#diff-62158ebeb309a68949be346b1193e9b3f43d384dd0f6af2f78afb785cd26bfa6R100-R116) [[2]](diffhunk://#diff-62158ebeb309a68949be346b1193e9b3f43d384dd0f6af2f78afb785cd26bfa6R130) [[3]](diffhunk://#diff-62158ebeb309a68949be346b1193e9b3f43d384dd0f6af2f78afb785cd26bfa6L396-R408)

**CLI and user-facing integration:**

* Added a `--use-zig-adapter` CLI option, corresponding struct field, and argument parsing logic in `src/cli.zig`, allowing users to select the Zig adapter at runtime. The usage information has also been updated. [[1]](diffhunk://#diff-0213d803b050248119f629ea8f3e9dc3a9dd5fc1c78cd3176ccdabebb6a1b4e7R66) [[2]](diffhunk://#diff-0213d803b050248119f629ea8f3e9dc3a9dd5fc1c78cd3176ccdabebb6a1b4e7R124) [[3]](diffhunk://#diff-0213d803b050248119f629ea8f3e9dc3a9dd5fc1c78cd3176ccdabebb6a1b4e7R191-R192)

**Developer tooling and benchmarking:**

* Added `scripts/benchmark_adapters.sh`, a script to benchmark and compare the performance of the C and Zig packet adapters, generating a markdown report with throughput and observations.
* Added `test_zig_adapter.sh`, a script for quickly building and testing the Zig adapter with debug output.